### PR TITLE
chore: add npm metadata links

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,14 @@
     "!src/__test__"
   ],
   "author": "Stefano Verna <s.verna@datocms.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/datocms/cda-client.git"
+  },
   "homepage": "https://github.com/datocms/cda-client",
+  "bugs": {
+    "url": "https://github.com/datocms/cda-client/issues"
+  },
   "license": "MIT",
   "dependencies": {
     "@0no-co/graphql.web": "^1.0.11"


### PR DESCRIPTION
﻿## Summary

This adds the standard npm metadata links to `package.json`:

- `repository` points to the GitHub repository
- `bugs.url` points to the GitHub issue tracker
- the existing homepage is kept unchanged

No runtime code, dependencies, generated files, exports, or package entry points are changed.

## Verification

- `node -e "const p=require('./package.json'); if (p.repository?.url !== 'https://github.com/datocms/cda-client.git' || p.bugs?.url !== 'https://github.com/datocms/cda-client/issues') process.exit(1)"`
- `git diff --cached --check`
- `npm pack --dry-run --json --ignore-scripts`
- `npm ci --ignore-scripts`
- `npm test` (1 test file, 9 tests passed)
- WSL Ubuntu 26.04: `npm pkg get repository homepage bugs --json`

I also ran `npm run build`; it currently fails on `src/executeQueryWithAutoPagination.ts(240,14)` with TS7006 (`variableDefinition` implicitly has `any`). That appears unrelated to this package metadata-only change.
