### PR TITLE
fix: resolve TS7006 build error and normalize repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "author": "Stefano Verna <s.verna@datocms.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/datocms/cda-client.git"
+    "url": "git+https://github.com/datocms/cda-client.git"
   },
   "homepage": "https://github.com/datocms/cda-client",
   "bugs": {

--- a/src/executeQueryWithAutoPagination.ts
+++ b/src/executeQueryWithAutoPagination.ts
@@ -237,7 +237,7 @@ export function convertToAutoPaginationQueryAndVariables<
         return {
           ...operationDefinition,
           variableDefinitions: operationDefinition.variableDefinitions?.filter(
-            (variableDefinition) => {
+            (variableDefinition: GraphQLWeb.VariableDefinitionNode) => {
               return !variablesToExclude.includes(
                 variableDefinition.variable.name.value,
               );


### PR DESCRIPTION
## Summary

Follow-up to #4. Two small fixes:

1. **Build fix (TS7006).** In `src/executeQueryWithAutoPagination.ts`, the `variableDefinitions?.filter(...)` callback parameter was relying on type inference from `visit()`. In environments where `visit()`'s return type degrades to `any` (e.g. a floated `@0no-co/graphql.web` minor or a newer TypeScript than the lockfile here), the param `variableDefinition` becomes implicitly `any`, failing `tsc` under `noImplicitAny` — exactly the `src/executeQueryWithAutoPagination.ts(240,14)` error reported in #4. Fixed with an explicit `GraphQLWeb.VariableDefinitionNode` annotation, which matches the locally-inferred type and is a no-op where inference already works.

2. **Metadata normalization.** `repository.url` changed from `https://…git` to the canonical `git+https://…git` form that `npm init` / `npm pkg fix` emit.

## Verification

- `npm run build` → exit 0 (both `tsc` and `tsc --project ./tsconfig.esnext.json`)
- `npm test` → 9/9 passed
- `npm pkg get repository` → `git+https://github.com/datocms/cda-client.git`